### PR TITLE
Unauth usage does not enter the auth logic

### DIFF
--- a/nigit.go
+++ b/nigit.go
@@ -278,7 +278,7 @@ func main() {
 			}
 
 			log.Infof("Handle %s -> %s", urlPath(programPath), program)
-			if c.GlobalString("auth") != "false" {
+			if c.GlobalString("auth") != "" {
 				authPath, err := checkPath(c.GlobalString("auth"))
 				if err != nil {
 					log.Fatal(err)


### PR DESCRIPTION
GlobalString will never return "false" whlie there are no such option existing,
it will return an empty string instead.