### PR TITLE
s/auth.py/auth.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ env variable. Thanks to @pdxjohnny for the implementation.
 
 
 ```bash
-./nigit --auth ./auth.py ./echo.sh
+./nigit --auth ./auth.sh ./echo.sh
 ```
 
 Example auth.sh


### PR DESCRIPTION
fix typo in auth instructions, the described auth script is a shell script not a python one
